### PR TITLE
Bugfix/fix travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 ---
 sudo: required
 language: python
+python:
+  - "2.7"
+  - "3.6"
+
 services:
   - docker
 cache:
@@ -11,7 +15,7 @@ before_install:
 install:
   - pip install molecule
   # - pip install required driver (e.g. docker, python-vagrant, shade, boto, apache-libcloud)
-  - pip install docker-py
+  - pip install docker
 script:
   - ansible --version
   - molecule --version

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 Ansible Percona Repo Role
 =========================
-[![Build Status](https://travis-ci.org/rmachuca89/ansible-repo-percona.svg?branch=master)](https://travis-ci.org/rmachuca89/ansible-repo-percona)
+[![Build Status](https://travis-ci.org/rmachuca89/ansible-percona-repo.svg?branch=master)](https://travis-ci.org/rmachuca89/ansible-percona-repo)
 
 A simple ansible role to install the [Percona Repository](https://www.percona.com/doc/percona-repo-config/index.html) on RHEL/CentOS and Debian/Ubuntu based machines.
 
@@ -26,7 +26,7 @@ Example Playbook
 ```yaml
 - hosts: dbs
   roles:
-      - repo-percona
+      - percona-repo
 ```
 
 License

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -22,5 +22,12 @@ scenario:
   name: default
 verifier:
   name: testinfra
+  env:
+    # get rid of the DeprecationWarning messages of third-party libs,
+    # see https://docs.pytest.org/en/latest/warnings.html#deprecationwarning-and-pendingdeprecationwarning
+    PYTHONWARNINGS: "ignore:.*U.*mode is deprecated:DeprecationWarning"
   lint:
     name: flake8
+  options:
+    # show which tests where executed in test output
+    v: 1

--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -2,4 +2,4 @@
 - name: Converge
   hosts: all
   roles:
-    - role: ansible-repo-percona
+    - role: ansible-percona-repo


### PR DESCRIPTION
- Fixed references to old repo (`ansible-repo-percona`) to new one (`ansible-percona-repo`)
- Updated travis config to include Python 2.7 and 3.6 versions
- Replaced `pip` dependency from `docker-py` (2.6 only) to `docker`