### PR TITLE
Replace invalid percona_repo galaxy tag with repository

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -22,7 +22,7 @@ galaxy_info:
   galaxy_tags:
     - percona
     - repo
-    - percona_repo
+    - repository
     - database
 
 dependencies: []


### PR DESCRIPTION
Fixes [failed travis build](https://travis-ci.org/rmachuca89/ansible-percona-repo/builds/517536826) by replacing an invalid tag `percona_repo` for ansible galaxy metadata.